### PR TITLE
Publish a rolling :master tag for Argo Image Updater

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,9 @@ jobs:
           tags: |
             type=sha,prefix=sha-,suffix=,format=short
             type=schedule,pattern={{date 'YYYYMMDD'}}
+            # Rolling tag so Argo Image Updater can track digest changes on a
+            # stable reference rather than a per-commit tag.
+            type=raw,value=master,enable={{is_default_branch}}
 
       - name: Build (and push if on master)
         id: docker_build


### PR DESCRIPTION
## Summary
Adds `type=raw,value=master,enable={{is_default_branch}}` to the docker/metadata-action tag list, so each successful master build also re-points `:master` to the new digest. The existing `sha-<short>` and daily `YYYYMMDD` tags are unchanged.

## Why
Argo Image Updater's `latest` strategy (which we tried first) writes overrides to `Application.spec.source.kustomize.images`, but the `seichi-minecraft-apps` `ApplicationSet` re-templates that field every reconcile, so the override never reaches the cluster. The `digest` strategy on a stable tag avoids that loop because the running pod gets a momentary `:master@sha256:NEW` image during the override window, the pull caches it locally, and subsequent reverts to plain `:master` resolve to the same cached digest.

This is the same shape mcserver--lobby has been using (stable `:1.0.0` tag with re-pushed digests).

## Test plan
- [ ] After merge, confirm `ghcr.io/giganticminecraft/seichi-game-data-server:master` exists and points at the latest digest
- [ ] Argo Image Updater no longer logs the "old image still latest" cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)