### PR TITLE
Stop double-shipping logs through OTLP

### DIFF
--- a/server/app/src/main.rs
+++ b/server/app/src/main.rs
@@ -100,7 +100,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_log_directives(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
         .with_otel(true)
         .with_metrics(true)
-        .with_logs(true)
         .init_subscriber()?;
 
     let _profiler_guard = profiler::try_start()?;


### PR DESCRIPTION
## Summary
Drops the OTLP logs exporter (`with_logs(true)` → default false).

The cluster's `k8s-monitoring-alloy-logs` DaemonSet already scrapes every pod's stdout into Loki, so enabling the OTLP logs path shipped every event into Loki twice — once as a tracing-subscriber JSON line through stdout scraping, once as an OTLP log record through `alloy-receiver`. Confirmed via Loki on the live cluster: same `sqlx::query` event present with both `exporter=OTLP` and the stdout-scraped shape, distinct labels but identical content.

Stdout-only also:
- matches every other Rust / Go / Java service in the cluster (single, uniform pipeline)
- keeps `kubectl logs` / `stern` useful
- is more resilient to `alloy-receiver` downtime (stdout is buffered by the kubelet)

Trade-off: the OTLP path's automatic `traceid` / `spanid` log attributes go away. The tracing-subscriber JSON still emits `span.otel.name`, `rpc.method`, `rpc.service` etc., so Tempo→Loki linking via service + timestamp remains practical, just one click longer.

## Test plan
- [x] `cargo check -p seichi-game-api` / `cargo fmt --check` clean
- [ ] After deploy: confirm `{exporter="OTLP", service_name="seichi-game-data-server"}` in Loki goes to zero while the stdout-scraped path keeps flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)