### PR TITLE
Enable tracing_level_info on otel middleware

### DIFF
--- a/server/app/Cargo.toml
+++ b/server/app/Cargo.toml
@@ -19,12 +19,6 @@ tracing = "0.1.41"
 # environment variables; if unset, the exporters stay disabled and the binary
 # falls back to plain stdout logging.
 init-tracing-opentelemetry = { version = "0.37", features = ["otlp", "tracing_subscriber_ext", "tracer", "metrics", "logs", "tls-webpki-roots"] }
-# tracing_level_info raises the middleware span level from TRACE to INFO.
-# Kept symmetric with publisher: the publisher inbound HTTP SERVER span was
-# missing without this feature, so prefer the same setting on every otel
-# middleware in the workspace to avoid the same symptom resurfacing if more
-# middlewares are added later. Upstream issue:
-# https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/330
 tonic-tracing-opentelemetry = { version = "0.32", features = ["tracing_level_info"] }
 opentelemetry = "0.31"
 pyroscope = { version = "2.0", features = ["backend-pprof-rs"] }

--- a/server/app/Cargo.toml
+++ b/server/app/Cargo.toml
@@ -19,6 +19,12 @@ tracing = "0.1.41"
 # environment variables; if unset, the exporters stay disabled and the binary
 # falls back to plain stdout logging.
 init-tracing-opentelemetry = { version = "0.37", features = ["otlp", "tracing_subscriber_ext", "tracer", "metrics", "logs", "tls-webpki-roots"] }
-tonic-tracing-opentelemetry = "0.32"
+# tracing_level_info raises the middleware span level from TRACE to INFO.
+# Kept symmetric with publisher: the publisher inbound HTTP SERVER span was
+# missing without this feature, so prefer the same setting on every otel
+# middleware in the workspace to avoid the same symptom resurfacing if more
+# middlewares are added later. Upstream issue:
+# https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/330
+tonic-tracing-opentelemetry = { version = "0.32", features = ["tracing_level_info"] }
 opentelemetry = "0.31"
 pyroscope = { version = "2.0", features = ["backend-pprof-rs"] }


### PR DESCRIPTION
## Summary
Adds the `tracing_level_info` feature to `tonic-tracing-opentelemetry`, raising the middleware-emitted span level from TRACE to INFO. Mirror of [publisher#163](https://github.com/GiganticMinecraft/seichi-game-data-publisher/pull/163).

## Why
On the publisher side, the inbound HTTP SERVER span was completely absent from Tempo, but on the server side the gRPC SERVER span is currently visible. Same crate family, same OTel pipeline — the asymmetric behaviour suggests the working server side is "lucky" rather than fundamentally different. Keeping both services on the same feature flip removes that latent risk and matches the upstream remedy ([issue #330](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/330)).

## Test plan
- [x] `cargo check -p seichi-game-api` / `cargo fmt --check` clean
- [ ] After deploy: `traces_spanmetrics_calls_total{service="seichi-game-data-server",span_kind="SPAN_KIND_SERVER"}` continues to be non-zero (no regression)
- [ ] Combined with publisher#163, confirm a single trace now contains both publisher SERVER + server SERVER spans linked by trace_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)