### PR TITLE
Document tracing_level_info as an operational level choice

### DIFF
--- a/server/app/Cargo.toml
+++ b/server/app/Cargo.toml
@@ -19,6 +19,8 @@ tracing = "0.1.41"
 # environment variables; if unset, the exporters stay disabled and the binary
 # falls back to plain stdout logging.
 init-tracing-opentelemetry = { version = "0.37", features = ["otlp", "tracing_subscriber_ext", "tracer", "metrics", "logs", "tls-webpki-roots"] }
+# tracing_level_info: emit OTel middleware spans at INFO instead of TRACE,
+# matching the default RUST_LOG=info under which this service runs.
 tonic-tracing-opentelemetry = { version = "0.32", features = ["tracing_level_info"] }
 opentelemetry = "0.31"
 pyroscope = { version = "2.0", features = ["backend-pprof-rs"] }


### PR DESCRIPTION
## Summary
Adds a one-liner above `tonic-tracing-opentelemetry` explaining that `tracing_level_info` is enabled to keep middleware spans at INFO, matching our default `RUST_LOG=info`. Mirror of [publisher#165](https://github.com/GiganticMinecraft/seichi-game-data-publisher/pull/165).

## Why
The original PR (#299) framed this feature as a fix for missing publisher SERVER spans. The real cause was identified later as OTLP/gRPC batches exceeding Tempo's 4 MiB receive limit. The feature flip itself is still desirable as a level-policy choice, so kept; only the rationale comment is updated.

## Test plan
- [x] `cargo check -p seichi-game-api` clean
- No runtime behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)