### PR TITLE
chore: dockerfile syntax directive をメジャーバージョン指定に揃える

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.26
+# syntax=docker/dockerfile:1
 FROM lukemathwalker/cargo-chef:latest-rust-1.96.1 AS chef
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

`# syntax=docker/dockerfile:1.xx` のようにマイナーバージョンまで固定していた syntax directive を `docker/dockerfile:1` に変更します。

メジャーバージョンのみの指定にすることで、BuildKit が常に最新の 1.x 系 Dockerfile frontend を使うようになり、バージョン更新の追従が不要になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
