### PR TITLE
fix: buf の protoc プラグインをローカル実行に移行し namely/protoc を置き換える

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,14 +34,16 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Dockerfile の bufbuild/buf イメージとバージョンを揃えること
+          version: "1.72.0"
 
       # pbjson-types などのビルドに protoc が必要
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
 
-      # buf generate (build.rs) が使う protoc プラグイン。バージョンは Dockerfile と揃えること
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンはスクリプト内で固定されている
       - name: Install protoc plugins for buf generate
-        run: cargo install protoc-gen-prost@0.5.0 protoc-gen-tonic@0.5.0 protoc-gen-prost-crate@0.5.0
+        run: ./server/install-buf-plugins.sh
 
       - name: Cargo fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,14 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # pbjson-types などのビルドに protoc が必要
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンは Dockerfile と揃えること
+      - name: Install protoc plugins for buf generate
+        run: cargo install protoc-gen-prost@0.5.0 protoc-gen-tonic@0.5.0 protoc-gen-prost-crate@0.5.0
+
       - name: Cargo fmt
         run: cargo fmt --all -- --check
         working-directory: ./server

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
 # We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
 RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
-# protoc plugins used by `buf generate` (see infra/grpc/buf.gen.yaml); versions must match the CI workflow
-RUN cargo install protoc-gen-prost@0.5.0 protoc-gen-tonic@0.5.0 protoc-gen-prost-crate@0.5.0
+# protoc plugins used by `buf generate`; versions are pinned in install-buf-plugins.sh
+COPY --link install-buf-plugins.sh ./
+RUN ./install-buf-plugins.sh
 
 COPY --from=planner --link /app/recipe.json recipe.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM lukemathwalker/cargo-chef:latest-rust-1.96.1 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.97.1 AS chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -8,16 +8,16 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM bufbuild/buf:1.72.0 AS buf
 
-FROM namely/protoc:1.42_2 AS protoc
-
 FROM chef AS build-env
-COPY --from=planner --link /app/recipe.json recipe.json
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
-COPY --from=protoc --link /usr/local/bin/protoc /usr/local/bin/
 
-# We need these because cargo chef cook will require protoc to build some modules
-ARG PROTOC_NO_VENDOR=true
-ARG PROTOC=/usr/local/bin/protoc
+# We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+# protoc plugins used by `buf generate` (see infra/grpc/buf.gen.yaml); versions must match the CI workflow
+RUN cargo install protoc-gen-prost@0.5.0 protoc-gen-tonic@0.5.0 protoc-gen-prost-crate@0.5.0
+
+COPY --from=planner --link /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json

--- a/server/infra/grpc/Cargo.toml
+++ b/server/infra/grpc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # pbjson-types, prost, tonic, tonic-prost は `<= 1.0.0` の範囲でminor versionが上がった場合全て一緒にbumpすること。
-# CI (ci.yaml) と Dockerfile でインストールしている protoc-gen-prost 系プラグインのバージョンをあげることも忘れずに。
+# server/install-buf-plugins.sh で固定している protoc-gen-prost 系プラグインのバージョンをあげることも忘れずに。
 
 domain = { path = "../../domain" }
 

--- a/server/infra/grpc/Cargo.toml
+++ b/server/infra/grpc/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# pbjson-types, prost, tonic, tonic-prost は `<= 1.0.0` の範囲でminor versionが上がった場合全て一緒にbumpすること。buf.gen.yamlの
-# バージョンをあげることも忘れずに。
+# pbjson-types, prost, tonic, tonic-prost は `<= 1.0.0` の範囲でminor versionが上がった場合全て一緒にbumpすること。
+# CI (ci.yaml) と Dockerfile でインストールしている protoc-gen-prost 系プラグインのバージョンをあげることも忘れずに。
 
 domain = { path = "../../domain" }
 

--- a/server/infra/grpc/buf.gen.yaml
+++ b/server/infra/grpc/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v2
 # 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
 # ローカルにインストールして使う (BSR のリモートプラグイン実行は未認証だと 10 req/h/IP の
 # レート制限があり、egress IP を共有する GitHub ホストランナーでは不安定になるため)。
-# インストールするバージョンは CI (ci.yaml) と Dockerfile を参照。
+# インストールは server/install-buf-plugins.sh で行う (バージョンはそこで固定)。
 plugins:
   - local: protoc-gen-prost
     out: src/gen

--- a/server/infra/grpc/buf.gen.yaml
+++ b/server/infra/grpc/buf.gen.yaml
@@ -1,20 +1,24 @@
 version: v2
+# 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
+# ローカルにインストールして使う (BSR のリモートプラグイン実行は未認証だと 10 req/h/IP の
+# レート制限があり、egress IP を共有する GitHub ホストランナーでは不安定になるため)。
+# インストールするバージョンは CI (ci.yaml) と Dockerfile を参照。
 plugins:
-  - remote: buf.build/community/neoeinstein-prost:v0.5.0
+  - local: protoc-gen-prost
     out: src/gen
     # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
     opt:
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
       - file_descriptor_set
-  - remote: buf.build/community/neoeinstein-tonic:v0.5.0
+  - local: protoc-gen-tonic
     out: src/gen
     # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic
     opt:
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
       - no_client=true
-  - remote: buf.build/community/neoeinstein-prost-crate:v0.5.0
+  - local: protoc-gen-prost-crate
     out: src/gen
     # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate
     opt:

--- a/server/install-buf-plugins.sh
+++ b/server/install-buf-plugins.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# buf generate (build.rs) が使う protoc プラグインを固定バージョンでインストールする。
+# CI・Dockerfile・開発環境で同じ生成結果になるよう、バージョン変更は必ずこのスクリプトだけで行うこと。
+# (バージョンは Cargo.toml の prost / tonic の世代と互換である必要がある)
+set -eu
+
+exec cargo install --locked \
+  protoc-gen-prost@0.5.0 \
+  protoc-gen-tonic@0.5.0 \
+  protoc-gen-prost-crate@0.5.0


### PR DESCRIPTION
## 背景

buf.gen.yaml が BSR の community remote plugins (`buf.build/community/neoeinstein-*`) を使っていますが、BSR のリモートプラグイン実行には[未認証だと 10 リクエスト/時/IP のレート制限](https://buf.build/docs/bsr/rate-limits/)があります。GitHub ホストランナーは egress IP を他のジョブと共有するため、CI がこの 429 を踏んで不安定になるリスクがあります(seichi-timed-stats-server の修理中に実際にこのレート制限に到達しました: GiganticMinecraft/seichi-timed-stats-server#164)。

## 変更内容

- **buf.gen.yaml をローカルプラグイン実行に移行**: リモートプラグインと同じバイナリである crates.io の `protoc-gen-prost@0.5.0` / `protoc-gen-tonic@0.5.0` / `protoc-gen-prost-crate@0.5.0` を CI と Dockerfile 内にインストールして使う構成に変更。生成コードは同一で、コード生成のレート制限リスクがなくなります
- **amd64 専用の `namely/protoc:1.42_2` を廃止**し、apt の `protobuf-compiler` に置換 (Apple Silicon などの arm64 ホストでもイメージをビルドできるように)
- **cargo-chef イメージを rust 1.97.1 に更新** (rust-toolchain.toml と一致させる)
- CI に protoc のインストールステップを追加 (pbjson-types のビルドに必要。これまではランナーにたまたま protoc が入っているか、キャッシュに依存していました)

## 動作確認

すべて手元 (macOS / Apple Silicon) で確認済みです。

- `cargo fmt --check` / `cargo clippy --all-features` (エラー 0) / `cargo test --all-features`: Rust 1.97.1 で通過
- `container build` (apple/container CLI): linux/arm64 でイメージビルド成功 (従来は namely/protoc が amd64 専用のため不可能でした)
- スモークラン: バイナリが正常に起動し、環境変数未設定による期待どおりの設定エラーで終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
